### PR TITLE
ci: fix deploy script

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.PUSH_TOKEN }}
           publish_dir: ./artifact
           publish_branch: master
           cname: ${{ secrets.BASE_URL }}


### PR DESCRIPTION
## 概要

CIのデプロイスクリプトの修正を行った。

## 詳細

デプロイ時に使用するトークンをCI由来のものではなく、 @shun-shobon のものにすることによってbranch protectionを回避するようにした。