### PR TITLE
アクセシビリティの向上など

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -7,6 +7,7 @@ const Page = ({ Component, pageProps }: AppProps): JSX.Element => {
     <>
       <Head>
         <link rel="preconnect" href="https://cdn.jsdelivr.net" />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
       </Head>
       <Component {...pageProps} />
     </>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,8 +1,16 @@
 import { AppProps } from "next/app";
+import Head from "next/head";
 import "../sass/global.sass";
 
 const Page = ({ Component, pageProps }: AppProps): JSX.Element => {
-  return <Component {...pageProps} />;
+  return (
+    <>
+      <Head>
+        <link rel="preconnect" href="https://cdn.jsdelivr.net" />
+      </Head>
+      <Component {...pageProps} />
+    </>
+  );
 };
 
 export default Page;

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,0 +1,17 @@
+import Document, { Html, Head, Main, NextScript } from "next/document";
+
+class MyDocument extends Document {
+  render(): JSX.Element {
+    return (
+      <Html lang="ja">
+        <Head />
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
+}
+
+export default MyDocument;

--- a/src/sass/_color.variable.sass
+++ b/src/sass/_color.variable.sass
@@ -7,4 +7,4 @@ $text-color: #202e3b
 $bright-text-color: #a3bacf
 $warn: #f99f48
 $amount: 15
-$dark-main-color: #265952
+$dark-main-color: #409689

--- a/src/sass/_color.variable.sass
+++ b/src/sass/_color.variable.sass
@@ -7,3 +7,4 @@ $text-color: #202e3b
 $bright-text-color: #a3bacf
 $warn: #f99f48
 $amount: 15
+$dark-main-color: darken($main-color, $amount * 1.5)

--- a/src/sass/_color.variable.sass
+++ b/src/sass/_color.variable.sass
@@ -1,5 +1,5 @@
 $basis-color: #fff
-$main-color: #0d8a7b
+$main-color: #6ac1B7
 $sub-color: #517d99
 $bright-main-color: #bfe9db
 $bright-sub-color: #dfefed

--- a/src/sass/_color.variable.sass
+++ b/src/sass/_color.variable.sass
@@ -7,4 +7,4 @@ $text-color: #202e3b
 $bright-text-color: #a3bacf
 $warn: #f99f48
 $amount: 15
-$dark-main-color: darken($main-color, $amount * 1.5)
+$dark-main-color: #265952

--- a/src/sass/_color.variable.sass
+++ b/src/sass/_color.variable.sass
@@ -1,5 +1,5 @@
 $basis-color: #fff
-$main-color: #6ac1B7
+$main-color: #0d8a7b
 $sub-color: #517d99
 $bright-main-color: #bfe9db
 $bright-sub-color: #dfefed

--- a/src/sass/_details.variable.sass
+++ b/src/sass/_details.variable.sass
@@ -1,4 +1,5 @@
-@import ./color.variable
+@import "./color.variable"
+
 $title-fontsize: 3
 $sub-fontsize: 1.6
 $main-fontsize: 1.1
@@ -67,8 +68,8 @@ $large: "screen and (min-width: 1600px)"
   @return $thickness solid $color
 
 .title
-  +about-font($title-fontsize)
   padding: 1vh 0
+  +about-font($title-fontsize)
   @media #{$isPhone}
     +about-font($title-fontsize - 0.7)
 

--- a/src/sass/global.sass
+++ b/src/sass/global.sass
@@ -6,7 +6,7 @@
 
 html
   color: $text-color
-  font-family: YakuHanJP, Roboto, Noto Sans JP, -apple-system, BlinkMacSystemFont, Segoe UI, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif
+  font-family: YakuHanJP, Roboto, "Noto Sans JP", -apple-system, BlinkMacSystemFont, "Segoe UI", Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif
 
 *
   box-sizing: border-box

--- a/src/sass/global.sass
+++ b/src/sass/global.sass
@@ -1,12 +1,11 @@
-@import url(https://cdn.jsdelivr.net/npm/yakuhanjp@3.3.1/dist/css/yakuhanjp.min.css)
-@import url(https://fonts.googleapis.com/css?family=Noto+Sans+JP&display=swap)
-@import /color.variable
-@import /details.variable
+@import url("https://cdn.jsdelivr.net/npm/yakuhanjp@3.3.1/dist/css/yakuhanjp.min.css")
+@import url("https://fonts.googleapis.com/css?family=Noto+Sans+JP&display=swap")
+@import "/color.variable"
+@import "/details.variable"
 
 html
   color: $text-color
-  font-family: YakuHanJP, Roboto, Noto Sans JP, -apple-system, BlinkMacSystemFont, Segoe UI, Oxygen,
-  Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif
+  font-family: YakuHanJP, Roboto, Noto Sans JP, -apple-system, BlinkMacSystemFont, Segoe UI, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif
 
 *
   box-sizing: border-box

--- a/src/sass/pages/blog.module.sass
+++ b/src/sass/pages/blog.module.sass
@@ -1,6 +1,6 @@
-@import ../color.variable
-@import ../details.variable
-@import ../wrapper.module
+@import "../color.variable"
+@import "../details.variable"
+@import "../wrapper.module"
 
 .main
   @extend .enumerate-contents-wrapper
@@ -20,8 +20,8 @@
 
 .pageLink
   color: $main-color
-  +about-font($little-fontsize)
   cursor: pointer
+  +about-font($little-fontsize)
   &:hover
     text-decoration: none
     +hover-line

--- a/src/sass/pages/index.module.sass
+++ b/src/sass/pages/index.module.sass
@@ -56,8 +56,9 @@
     +triangle($thickness: 10vh)
 
 .genkaiLink
-  padding: 0 0.3rem
+  padding: 0 0.1rem
   cursor: pointer
   color: $dark-main-color
-  &:hover
-    +hover-line
+  font-style: italic
+  text-decoration: solid
+  text-decoration-line: underline

--- a/src/sass/pages/index.module.sass
+++ b/src/sass/pages/index.module.sass
@@ -58,7 +58,7 @@
 .genkaiLink
   padding: 0 0.1rem
   cursor: pointer
-  color: $dark-main-color
+  color: $text-color
   font-style: italic
   text-decoration: solid
   text-decoration-line: underline

--- a/src/sass/pages/index.module.sass
+++ b/src/sass/pages/index.module.sass
@@ -40,7 +40,7 @@
     font-weight: normal
     +about-font($main-fontsize - 0.1)
     span
-      color: darken($main-color, $amount * 1.5)
+      color: $dark-main-color
       margin-right: 0.5rem
       font-family: "Roboto Mono", Roboto, monospace
       +about-font($sub-fontsize)
@@ -58,6 +58,6 @@
 .genkaiLink
   padding: 0 0.3rem
   cursor: pointer
-  color: darken($main-color, $amount * 1.5)
+  color: $dark-main-color
   &:hover
     +hover-line

--- a/src/sass/pages/index.module.sass
+++ b/src/sass/pages/index.module.sass
@@ -9,23 +9,23 @@
   position: relative
 
 .title
-  +about-font(4)
   padding-top: $padding
   padding-bottom: 0.5rem
   position: relative
   text-align: center
+  +about-font(4)
   @media #{$middle}
     +about-font($title-fontsize - 0.3)
   @media #{$min}
     +about-font($title-fontsize - 0.5)
 
 .subtitle
-  +about-font($sub-fontsize)
   font-style: italic
   padding-bottom: $min-padding
+  +about-font($sub-fontsize)
   @media #{$middle}
-    +about-font($sub-fontsize - 0.3)
     padding-bottom: $padding
+    +about-font($sub-fontsize - 0.3)
   @media #{$min}
     +about-font($sub-fontsize - 0.5)
 
@@ -36,13 +36,13 @@
 
 .aboutUs
   p
-    +about-font($main-fontsize - 0.1)
     font-weight: normal
+    +about-font($main-fontsize - 0.1)
     span
-      +about-font($sub-fontsize)
-      color: darken($main-color, 12)
+      color: darken($main-color, $amount * 1.5)
       margin-right: 0.5rem
       font-weight: bold
+      +about-font($sub-fontsize)
 
 .title::after
   content: ""
@@ -57,6 +57,6 @@
 .genkaiLink
   padding: 0 0.3rem
   cursor: pointer
-  color: darken($main-color, 12)
+  color: darken($main-color, $amount * 1.5)
   &:hover
     +hover-line

--- a/src/sass/pages/index.module.sass
+++ b/src/sass/pages/index.module.sass
@@ -42,7 +42,7 @@
     span
       color: darken($main-color, $amount * 1.5)
       margin-right: 0.5rem
-      font-family: 'Roboto Mono', Roboto, monospace
+      font-family: "Roboto Mono", Roboto, monospace
 
 .title::after
   content: ""

--- a/src/sass/pages/index.module.sass
+++ b/src/sass/pages/index.module.sass
@@ -43,6 +43,7 @@
       color: darken($main-color, $amount * 1.5)
       margin-right: 0.5rem
       font-family: "Roboto Mono", Roboto, monospace
+      +about-font($sub-fontsize)
 
 .title::after
   content: ""

--- a/src/sass/pages/index.module.sass
+++ b/src/sass/pages/index.module.sass
@@ -1,6 +1,6 @@
-@import ../details.variable
-@import ../color.variable
-@import ../wrapper.module
+@import "../details.variable"
+@import "../color.variable"
+@import "../wrapper.module"
 
 .homeMainContents
   @extend .wrapper

--- a/src/sass/pages/index.module.sass
+++ b/src/sass/pages/index.module.sass
@@ -40,7 +40,7 @@
     font-weight: normal
     span
       +about-font($sub-fontsize)
-      color: $main-color
+      color: darken($main-color, 12)
       margin-right: 0.5rem
       font-weight: bold
 
@@ -57,6 +57,6 @@
 .genkaiLink
   padding: 0 0.3rem
   cursor: pointer
-  color: $main-color
+  color: darken($main-color, 12)
   &:hover
     +hover-line

--- a/src/sass/pages/join.module.sass
+++ b/src/sass/pages/join.module.sass
@@ -3,6 +3,7 @@
 @import "../wrapper.module"
 
 .joinPage
+  min-width: 80%
   .title
     text-align: center
   *

--- a/src/sass/pages/join.module.sass
+++ b/src/sass/pages/join.module.sass
@@ -1,12 +1,12 @@
-@import ../details.variable
-@import ../color.variable
-@import ../wrapper.module
+@import "../details.variable"
+@import "../color.variable"
+@import "../wrapper.module"
 
 .joinPage
-  +flex-style
   flex-direction: column
   padding: 0 $min-padding
   min-width: 80%
+  +flex-style
 
 .joinText
   @extend .text

--- a/src/sass/pages/join.module.sass
+++ b/src/sass/pages/join.module.sass
@@ -3,15 +3,15 @@
 @import "../wrapper.module"
 
 .joinPage
-  text-align: center
-  padding: 0 $min-padding
-  min-width: 80%
-  > * + *
+  .title
     text-align: center
+  *
+    text-align: left
 
 .joinText
   @extend .text
-  padding: 2%
+  margin: 2% auto
+  padding: 0 $min-padding + 2%
 
 .color
   +hover-line

--- a/src/sass/pages/join.module.sass
+++ b/src/sass/pages/join.module.sass
@@ -3,10 +3,11 @@
 @import "../wrapper.module"
 
 .joinPage
-  flex-direction: column
+  text-align: center
   padding: 0 $min-padding
   min-width: 80%
-  +flex-style
+  > * + *
+    text-align: center
 
 .joinText
   @extend .text

--- a/src/sass/pages/join.module.sass
+++ b/src/sass/pages/join.module.sass
@@ -11,8 +11,11 @@
 
 .joinText
   @extend .text
-  margin: 2% auto
-  padding: 0 $min-padding + 2%
+  max-width: 32.5rem
+  margin: 0 auto
+  padding: 2% 0
+  @media #{$isPhone}
+    padding: 2% 2% + $min-padding
 
 .color
   +hover-line

--- a/src/sass/pages/member.module.sass
+++ b/src/sass/pages/member.module.sass
@@ -1,13 +1,13 @@
-@import ../wrapper.module
-@import ../color.variable
-@import ../details.variable
+@import "../wrapper.module"
+@import "../color.variable"
+@import "../details.variable"
 
 .memberMainContents
   @extend .enumerate-contents-wrapper
 
 .linksContainer
-  +phone
   margin-top: $min-padding
+  +phone
 
 .linksContainer > * + *
   margin-left: 1.1rem

--- a/src/sass/wrapper.module.sass
+++ b/src/sass/wrapper.module.sass
@@ -1,14 +1,14 @@
-@import /details.variable
+@import "/details.variable"
 
 =phone
   @media #{$isPhone}
     justify-content: flex-start
 
 .mainContents
-  +flex-style
   min-width: 100%
   min-height: 100vh
   flex: 1
+  +flex-style
 
 .wrapper
   width: 100%
@@ -35,8 +35,8 @@
 
 .avatarWrapper,
 .avatar
-  +cancel-background-color
   height: 100%
+  +cancel-background-color
 
 .avatar
   width: 37%
@@ -58,5 +58,5 @@
   @media #{$large}
     +make-padding($large)
   @media #{$isPhone}
-    +make-padding($isPhone)
     text-align: left
+    +make-padding($isPhone)


### PR DESCRIPTION
変更点:

- アクセシビリティ向上のため、トップ画面の色付き文字のコントラストを大きくした
- Sass の Linter に従った
  - `@import` のパスに引用符をつけた
  - 指定の順番を変えた
- 外部 CSS のドメインへの `preconnect` を追加した
- HTML 要素に `lang` 属性を追加した
- Roboto Mono の指定がシングルクォートだったのでダブルクォートにした
