### PR TITLE
CI に Next.js のキャッシュを追加

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ github.ref }}-
             ${{ runner.os }}-
+      - uses: actions/cache@v2
+        with:
+          path: ${{ github.workspace }}/.next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/yarn.lock') }}
       - uses: actions/setup-node@v1
         with:
           node-version: 12.x

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ${{ github.workspace }}/.next/cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('yarn.lock') }}
       - uses: actions/setup-node@v1
         with:
           node-version: 12.x


### PR DESCRIPTION
なんか CI のコンソールに警告が出てたので

### 参考リンク
[errors/no-cache](https://github.com/vercel/next.js/blob/master/errors/no-cache.md)
