### PR TITLE
プライバシーポリシーの追加

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -20,6 +20,10 @@ const links: { name: string; url: string }[] = [
     name: "参加方法",
     url: "/join",
   },
+  {
+    name: "当サイトについて",
+    url: "/policy",
+  },
 ];
 export const Header: FC = () => (
   <>

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -21,7 +21,7 @@ const links: { name: string; url: string }[] = [
     url: "/join",
   },
   {
-    name: "当サイトについて",
+    name: "プライバシーポリシー",
     url: "/policy",
   },
 ];

--- a/src/pages/policy.tsx
+++ b/src/pages/policy.tsx
@@ -1,0 +1,56 @@
+import { NextPage } from "next";
+import { Header } from "../components/header";
+import { Layout } from "../components/layout";
+import styles from "../scss/pages/policy.module.scss";
+
+const JoinPage: NextPage = () => (
+  <>
+    <Layout pageName="限界開発鯖 - 当サイトについて">
+      <Header />
+      <main className={styles.policyPage}>
+        <h1 className={styles.title}>プライバシーポリシー</h1>
+        <section className={styles.policyText}>
+          <p className={styles.textindent1em}>
+            当サイトでは、主に今後のサイトの改善に役立てるため、 Google
+            LLCが提供しているアクセス分析ツール「Google Analytics」を
+            使用したアクセス解析を行っております。
+          </p>
+
+          <p className={styles.textindent1em}>
+            Google Analyticsでは、当サイトが発行したCookie等を用いて、
+            アクセス状況や閲覧環境といったWebサイトの利用データを収集しております。
+          </p>
+
+          <p className={styles.textindent1em}>
+            Cookieの利用につきましては、Google Analyticsのプライバシーポリシーと
+            規約に基づいております。
+          </p>
+
+          <p className={styles.textindent1em}>
+            <span className={styles.color}>
+              取得したデータの使用は当サイトの改善に役立てるために限り、その他の
+              目的での使用は一切致しません。
+            </span>
+            また、このデータは匿名で取得されているため、 個人の特定等は一切致しません。
+          </p>
+
+          <p className={styles.textindent1em}>
+            規約の詳細に関しましては、
+            <a href="https://marketingplatform.google.com/about/analytics/terms/jp/">
+              Google アナリティクス利用規約
+            </a>
+            や<a href="https://policies.google.com/technologies/ads?hl=ja">Googleポリシーと規約</a>
+            のページをご覧ください。
+          </p>
+
+          <p className={styles.textindent1em}>
+            また、上記までで挙げた機能はCookieを無効にすることでデータの収集を拒否
+            することができますので、お使いのブラウザの設定をご確認ください。
+          </p>
+        </section>
+      </main>
+    </Layout>
+  </>
+);
+
+export default JoinPage;

--- a/src/pages/policy.tsx
+++ b/src/pages/policy.tsx
@@ -1,51 +1,41 @@
 import { NextPage } from "next";
 import { Header } from "../components/header";
 import { Layout } from "../components/layout";
+import { ExternalLink } from "../components/externalLink";
 import styles from "../scss/pages/policy.module.scss";
 
-const policyPage: NextPage = () => (
+const PolicyPage: NextPage = () => (
   <>
-    <Layout pageName="限界開発鯖 - 当サイトについて">
+    <Layout pageName="限界開発鯖 - プライバシーポリシー">
       <Header />
       <main className={styles.policyPage}>
         <h1 className={styles.title}>プライバシーポリシー</h1>
         <section className={styles.policyText}>
-          <p className={styles.textindent1em}>
-            当サイトでは、主に今後のサイトの改善に役立てるため、 Google
-            LLCが提供しているアクセス分析ツール「Google Analytics」を
-            使用したアクセス解析を行っております。
-          </p>
+          <p className={styles.textindent1em}>当サイトはGoogleアナリティクスを使用しております。</p>
 
           <p className={styles.textindent1em}>
-            Google Analyticsでは、当サイトが発行したCookie等を用いて、
-            アクセス状況や閲覧環境といったWebサイトの利用データを収集しております。
-          </p>
-
-          <p className={styles.textindent1em}>
-            Cookieの利用につきましては、Google Analyticsのプライバシーポリシーと
-            規約に基づいております。
-          </p>
-
-          <p className={styles.textindent1em}>
+            取得するデータは当サイトの改善に役立てる事のみに使用するとし、
             <span className={styles.color}>
-              取得したデータの使用は当サイトの改善に役立てるために限り、その他の
-              目的での使用は一切致しません。
+              個人の特定やその他個人の不利益に関わることは致しません。
             </span>
-            また、このデータは匿名で取得されているため、 個人の特定等は一切致しません。
           </p>
 
           <p className={styles.textindent1em}>
             規約の詳細に関しましては、
-            <a href="https://marketingplatform.google.com/about/analytics/terms/jp/">
+            <ExternalLink
+              href="https://marketingplatform.google.com/about/analytics/terms/jp/"
+              className={styles.link}
+            >
               Google アナリティクス利用規約
-            </a>
-            や<a href="https://policies.google.com/technologies/ads?hl=ja">Googleポリシーと規約</a>
+            </ExternalLink>
+            や
+            <ExternalLink
+              href="https://policies.google.com/technologies/ads?hl=ja"
+              className={styles.link}
+            >
+              Googleポリシーと規約
+            </ExternalLink>
             のページをご覧ください。
-          </p>
-
-          <p className={styles.textindent1em}>
-            また、上記までで挙げた機能はCookieを無効にすることでデータの収集を拒否
-            することができますので、お使いのブラウザの設定をご確認ください。
           </p>
         </section>
       </main>
@@ -53,4 +43,4 @@ const policyPage: NextPage = () => (
   </>
 );
 
-export default policyPage;
+export default PolicyPage;

--- a/src/pages/policy.tsx
+++ b/src/pages/policy.tsx
@@ -11,7 +11,9 @@ const PolicyPage: NextPage = () => (
       <main className={styles.policyPage}>
         <h1 className={styles.title}>プライバシーポリシー</h1>
         <section className={styles.policyText}>
-          <p className={styles.textindent1em}>当サイトはGoogleアナリティクスを使用しております。</p>
+          <p className={styles.textindent1em}>
+            当サイトは Google アナリティクスを使用しております。
+          </p>
 
           <p className={styles.textindent1em}>
             取得するデータは当サイトの改善に役立てる事のみに使用するとし、
@@ -33,7 +35,7 @@ const PolicyPage: NextPage = () => (
               href="https://policies.google.com/technologies/ads?hl=ja"
               className={styles.link}
             >
-              Googleポリシーと規約
+              Google ポリシーと規約
             </ExternalLink>
             のページをご覧ください。
           </p>

--- a/src/pages/policy.tsx
+++ b/src/pages/policy.tsx
@@ -3,7 +3,7 @@ import { Header } from "../components/header";
 import { Layout } from "../components/layout";
 import styles from "../scss/pages/policy.module.scss";
 
-const JoinPage: NextPage = () => (
+const policyPage: NextPage = () => (
   <>
     <Layout pageName="限界開発鯖 - 当サイトについて">
       <Header />
@@ -53,4 +53,4 @@ const JoinPage: NextPage = () => (
   </>
 );
 
-export default JoinPage;
+export default policyPage;

--- a/src/scss/pages/policy.module.scss
+++ b/src/scss/pages/policy.module.scss
@@ -38,3 +38,12 @@
 .textindent1em {
   text-indent: 1em;
 }
+
+.link {
+  padding: 0 0.1rem;
+  font-style: italic;
+  color: color.get-text-color("main");
+  text-decoration: solid;
+  cursor: pointer;
+  text-decoration-line: underline;
+}

--- a/src/scss/pages/policy.module.scss
+++ b/src/scss/pages/policy.module.scss
@@ -1,0 +1,40 @@
+@use "../details.variable";
+@use "../color.variable";
+@use "../wrapper.module";
+
+.policyPage {
+  min-width: 80%;
+
+  .title {
+    text-align: center;
+  }
+
+  * {
+    text-align: left;
+  }
+}
+
+.policyText {
+  @extend .text;
+
+  max-width: 32.5rem;
+  padding: 2% 0;
+  margin: 0 auto;
+
+  @media #{details.$isPhone} {
+    padding: 2% 2% + details.$min-padding;
+  }
+
+  p {
+    margin: 0.6em;
+    line-height: 1.7;
+  }
+}
+
+.color {
+  @include details.hover-line ();
+}
+
+.textindent1em {
+  text-indent: 1em;
+}


### PR DESCRIPTION
# やったこと
- policyコンポーネントを追加し、プライバシーポリシーを書いた。
- ヘッダーのリンクに「当サイトについて」を追加し、プライバシーポリシーに飛ぶようにした。

# スクリーンショット
![image](https://user-images.githubusercontent.com/43064745/96234843-f43c2d80-0fd4-11eb-827b-d596226e3f4c.png)

# 関連するissue
#95 