### PR TITLE
Revert "🐛 Fix role of loxygen"

### DIFF
--- a/data/members/list.yaml
+++ b/data/members/list.yaml
@@ -9,7 +9,7 @@
 
 - name: loxygen
   avatar: https://github.com/loxygenK.png
-  role: 中出しメス堕ち担当大臣
+  role: 全知全能の神
   links:
     - type: twitter
       url: https://twitter.com/loxygenK


### PR DESCRIPTION
Reverts approvers/approvers.github.io#109
やめてね.