### PR TITLE
ブログ Markdown のスタイルの更新

### DIFF
--- a/data/blogs/001.md
+++ b/data/blogs/001.md
@@ -14,19 +14,21 @@ date: '2020-05-11'
 
 ##### テスト H5
 
-テスト
+*Italik*
 
 - A
 - B
 - C
 - D
 
+**Boldish**
+
 1. A
 2. B
 3. C
 4. D
 
-*Italik* **Boldish** ***Italik-Blodish***
+***Italik-Blodish***
 
 `test` は `important` です.
 

--- a/data/blogs/001.md
+++ b/data/blogs/001.md
@@ -27,3 +27,13 @@ date: '2020-05-11'
 4. D
 
 *Italik* **Boldish** ***Italik-Blodish***
+
+`test` は `important` です.
+
+`not important` は `not test` です.
+
+```cpp
+int main() {
+  return -1;
+}
+```

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.15.1",
     "@fortawesome/react-fontawesome": "^0.1.9",
     "date-fns": "^2.13.0",
+    "emojify-tag": "^1.0.0",
     "gray-matter": "^4.0.2",
     "markdown-to-jsx": "^7.0.1",
     "next": "^10.0.0",

--- a/src/@types/emojify-tag.d.ts
+++ b/src/@types/emojify-tag.d.ts
@@ -1,0 +1,3 @@
+declare module "emojify-tag" {
+  export default function (strings: readonly strings[], ...args: unknown[]);
+}

--- a/src/pages/blog/[id].tsx
+++ b/src/pages/blog/[id].tsx
@@ -3,6 +3,7 @@ import type { GetStaticPaths, GetStaticProps, NextPage } from "next";
 import { DateString } from "../../components/date";
 import { Layout } from "../../components/layout";
 import Markdown from "markdown-to-jsx";
+import emojify from "emojify-tag";
 import styles from "../../scss/pages/blog/markdown.module.scss";
 
 type BlogPostPageProps = {
@@ -14,7 +15,7 @@ const BlogPostPage: NextPage<BlogPostPageProps> = ({ post }) => (
     <h1 className={styles.title}>{post.title}</h1>
     <DateString dateString={post.date} />
     <div className={styles.markdown}>
-      <Markdown>{post.content}</Markdown>
+      <Markdown>{emojify`${post.content}`}</Markdown>
     </div>
   </Layout>
 );

--- a/src/scss/pages/blog/markdown.module.scss
+++ b/src/scss/pages/blog/markdown.module.scss
@@ -1,10 +1,10 @@
+@use "../../color.variable";
 @use "../../media.variable";
 
 .markdown {
   width: 60%;
   min-height: 100%;
-  padding: 0 1.5rem;
-  padding-top: 1rem;
+  padding: 4rem 1.5rem;
   text-align: left;
 
   @media #{media.query(middle)} {
@@ -13,5 +13,34 @@
 
   @media #{media.query(phone)} {
     width: 90%;
+  }
+
+  h1 {
+    padding-top: 2rem;
+  }
+
+  h2 {
+    padding-top: 1.5rem;
+  }
+
+  p {
+    padding-top: 0.5rem;
+  }
+
+  ul,
+  ol {
+    padding: 0.25rem 2rem;
+  }
+
+  details {
+    padding-left: 1rem;
+  }
+
+  pre,
+  code {
+    @include color.text(sub, back);
+
+    padding: 0 0.25rem;
+    border-radius: 0.25rem;
   }
 }

--- a/src/scss/pages/blog/markdown.module.scss
+++ b/src/scss/pages/blog/markdown.module.scss
@@ -36,8 +36,7 @@
     padding-left: 1rem;
   }
 
-  pre,
-  code {
+  pre {
     @include color.text(sub, back);
 
     padding: 0.25rem;

--- a/src/scss/pages/blog/markdown.module.scss
+++ b/src/scss/pages/blog/markdown.module.scss
@@ -23,6 +23,18 @@
     padding-top: 1.5rem;
   }
 
+  h3 {
+    padding-top: 1rem;
+  }
+
+  h4 {
+    padding-top: 0.5rem;
+  }
+
+  h5 {
+    padding-top: 0.25rem;
+  }
+
   p {
     padding-top: 0.5rem;
   }

--- a/src/scss/pages/blog/markdown.module.scss
+++ b/src/scss/pages/blog/markdown.module.scss
@@ -40,7 +40,8 @@
   code {
     @include color.text(sub, back);
 
-    padding: 0 0.25rem;
+    padding: 0.25rem;
+    margin: 0.25rem 0;
     border-radius: 0.25rem;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2071,6 +2071,18 @@ emoji-regex@^8.0.0:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
+emojify-tag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/emojify-tag/-/emojify-tag-1.0.0.tgz#64759f626e38689108eced36892c5856b841b6ce"
+  integrity sha1-ZHWfYm44aJEI7O02iSxYVrhBts4=
+  dependencies:
+    emojione "^2.2.6"
+
+emojione@^2.2.6:
+  version "2.2.7"
+  resolved "https://registry.yarnpkg.com/emojione/-/emojione-2.2.7.tgz#46457cf6b9b2f8da13ae8a2e4e547de06ee15e96"
+  integrity sha1-RkV89rmy+NoTroouTlR94G7hXpY=
+
 emojis-list@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"


### PR DESCRIPTION
- 絵文字タグを絵文字に変換する機能を追加
- 各段落の余白を追加
- コード部の色 (青色になっているので要合意) を追加
