### PR TITLE
ブログページのスタイルの Hotfix

### DIFF
--- a/src/pages/blog.tsx
+++ b/src/pages/blog.tsx
@@ -6,7 +6,6 @@ import { DateString } from "../components/date";
 import type { FC } from "react";
 import { Layout } from "../components/layout";
 import Link from "next/link";
-import { Paper } from "../components/paper";
 import { Title } from "../components/title";
 import styles from "../scss/pages/blog.module.scss";
 

--- a/src/pages/blog.tsx
+++ b/src/pages/blog.tsx
@@ -11,7 +11,7 @@ import { Title } from "../components/title";
 import styles from "../scss/pages/blog.module.scss";
 
 const BlogCard: FC<Metadata> = ({ id, title, date }) => (
-  <Paper>
+  <div className={styles.blogCard}>
     <Avatar name={title} />
     <div className={styles.cardText}>
       <h3 className={styles.blogTitle}>{title}</h3>
@@ -22,7 +22,7 @@ const BlogCard: FC<Metadata> = ({ id, title, date }) => (
         </Button>
       </Link>
     </div>
-  </Paper>
+  </div>
 );
 
 const BlogPage: NextPage<{ blogs: Metadata[] }> = ({ blogs }) => (

--- a/src/scss/pages/blog.module.scss
+++ b/src/scss/pages/blog.module.scss
@@ -2,9 +2,21 @@
 @use "../details.variable";
 @use "../media.variable";
 
+.blogCard {
+  display: flex;
+  align-items: center;
+  max-width: 80%;
+  margin: 1em;
+
+  img {
+    width: 20%;
+  }
+}
+
 .main {
   @include details.enumerate-contents-wrapper();
 
+  flex-direction: column;
   justify-content: flex-start;
 }
 
@@ -22,8 +34,6 @@
 
 .blogTitle {
   @extend .name;
-
-  word-break: keep-all;
 }
 
 .blogContents {

--- a/src/scss/pages/blog/markdown.module.scss
+++ b/src/scss/pages/blog/markdown.module.scss
@@ -1,11 +1,8 @@
 @use "../../color.variable";
 @use "../../media.variable";
 
-.markdown {
+@mixin centered-body {
   width: 60%;
-  min-height: 100%;
-  padding: 4rem 1.5rem;
-  text-align: left;
 
   @media #{media.query(middle)} {
     width: 70%;
@@ -14,6 +11,21 @@
   @media #{media.query(phone)} {
     width: 90%;
   }
+}
+
+.title {
+  @include centered-body();
+
+  padding: 0 1.5rem;
+  text-align: center;
+}
+
+.markdown {
+  @include centered-body();
+
+  min-height: 100%;
+  padding: 4rem 1.5rem;
+  text-align: left;
 
   h1 {
     padding-top: 2rem;


### PR DESCRIPTION
記念すべきフライさんによるブログの初投稿ですが,
スタイルが崩れて悲しいことになっていたため急遽修正

- fix: Hotfix blog list page's style
- fix: Hotfix blog page's style

変更後の見た目の例:

<img width="785" alt="スクリーンショット 2021-01-11 4 13 23" src="https://user-images.githubusercontent.com/10331164/104186556-ec681a00-5459-11eb-96fd-176692203966.png">
<img width="752" alt="スクリーンショット 2021-01-11 4 19 41" src="https://user-images.githubusercontent.com/10331164/104186571-f1c56480-5459-11eb-93ea-3d99f17f01ec.png">

