### PR TITLE
ブログページのレスポンシブ対応

### DIFF
--- a/src/scss/pages/blog/markdown.module.scss
+++ b/src/scss/pages/blog/markdown.module.scss
@@ -65,6 +65,12 @@
 
     padding: 0.25rem;
     margin: 0.25rem 0;
+    overflow-x: scroll;
     border-radius: 0.25rem;
+  }
+
+  img {
+    max-width: 100%;
+    height: auto;
   }
 }


### PR DESCRIPTION
幅の小さい画面でも画像とコードブロックがはみ出さなくなりました.

