### PR TITLE
メニューのデザインの改善など

### DIFF
--- a/src/scss/_color.variable.scss
+++ b/src/scss/_color.variable.scss
@@ -56,3 +56,13 @@ $warn: #f99f48;
 
   @include applyColor(map.get($text, $color), $target);
 }
+
+@mixin back($color: normal) {
+  $back: (
+    dark: #dfdfdf,
+    normal: #e7e7e7,
+    light: #f7f7f7,
+  );
+
+  background-color: map.get($back, $color);
+}

--- a/src/scss/components/navigation.module.scss
+++ b/src/scss/components/navigation.module.scss
@@ -10,7 +10,7 @@
 
   & > div {
     width: 100%;
-    padding: 0 1rem;
+    padding: 0 2rem;
     margin: 1rem 0;
   }
 }
@@ -30,13 +30,14 @@
 }
 
 .navWrapper {
-  @include color.main(normal, border);
+  @include color.main(normal, border-right);
   @include color.sub(light, back);
 
-  position: fixed;
-  right: 0.5rem;
-  bottom: 0.5rem;
+  position: absolute;
+  top: 0;
+  left: 0;
   z-index: 10;
+  height: 100vh;
   border: thin solid;
   transition: opacity 0.13s;
 }

--- a/src/scss/components/navigation.module.scss
+++ b/src/scss/components/navigation.module.scss
@@ -10,8 +10,15 @@
 
   & > div {
     width: 100%;
-    padding: 0 2rem;
+    padding: 0 2rem 0 1rem;
     margin: 1rem 0;
+
+    &::before {
+      @include color.text();
+
+      font-size: 1.5rem;
+      content: "| ";
+    }
   }
 }
 

--- a/src/scss/components/navigation.module.scss
+++ b/src/scss/components/navigation.module.scss
@@ -23,17 +23,23 @@
 }
 
 .navButton {
-  @include color.text(sub, front);
-  @include color.sub(dark, back);
+  @media #{media.query(phone)} {
+    @include color.text(sub, front);
+    @include color.sub(dark, back);
 
-  position: fixed;
-  bottom: 0.5rem;
-  left: 0.5rem;
-  z-index: 20;
-  width: 4rem;
-  height: 4rem;
-  font-size: 2rem;
-  border-radius: 50%;
+    position: fixed;
+    bottom: 0.5rem;
+    left: 0.5rem;
+    z-index: 20;
+    width: 4rem;
+    height: 4rem;
+    font-size: 2rem;
+    border-radius: 50%;
+  }
+
+  @media not #{media.query(phone)} {
+    display: none;
+  }
 }
 
 .navWrapper {
@@ -50,5 +56,7 @@
 }
 
 .navWrapper[data-showing="false"] {
-  opacity: 0;
+  @media #{media.query(phone)} {
+    opacity: 0;
+  }
 }

--- a/src/scss/components/navigation.module.scss
+++ b/src/scss/components/navigation.module.scss
@@ -31,7 +31,7 @@
 
 .navWrapper {
   @include color.main(normal, border-right);
-  @include color.sub(light, back);
+  @include color.back(dark);
 
   position: absolute;
   top: 0;

--- a/src/scss/global.scss
+++ b/src/scss/global.scss
@@ -7,6 +7,7 @@
 
 html {
   @include color.text();
+  @include color.back();
 
   font-family:
     YakuHanJP,


### PR DESCRIPTION
- `color.back` を追加
- サイトグローバルの背景色を設定
- 大きい画面でメニューが常に表示されるように修正
- メニューの項目に装飾を追加

参考画像:
<img width="397" alt="スクリーンショット" src="https://user-images.githubusercontent.com/10331164/113481807-b2e20080-94d6-11eb-9da3-5bfa35192be3.png">

